### PR TITLE
Extended the DBS with an setItemTemplate function, extended reloadFil…

### DIFF
--- a/src/components/DataBoundScrollView.js
+++ b/src/components/DataBoundScrollView.js
@@ -62,17 +62,26 @@ export class DataBoundScrollView extends FlexScrollView {
             console.log('No DataSource was set.');
         }
     }
+    /**
+     * Set a template function
+     * @param templateFunction
+     */
+    setItemTemplate(templateFunction = {}){
+        this.options.itemTemplate = templateFunction;
+    }
 
     /**
      * Reloads the dataFilter option of the DataBoundScrollView, and verifies whether the items in the dataStore are allowed by the new filter.
      * It removes any currently visible items that aren't allowed anymore, and adds any non-visible ones that are allowed now.
      * @param {Function} newFilter New filter function to verify item visibility with.
+     * @param {Boolean} reRender Boolean to rerender all childs that pass the filter function. Usefull when setting a new itemTemplate alongside reloading the filter
      * @returns {void}
      */
-    reloadFilter(newFilter) {
+    reloadFilter(newFilter, reRender = false) {
         this.options.dataFilter = newFilter;
 
         for (let entry of this.options.dataStore) {
+            if(reRender) this._removeItem(entry);
             let surface = _.find(this._dataSource, (surface) => surface.dataId === entry.id);
             let alreadyExists = surface !== undefined;
             let result = newFilter(entry);

--- a/src/components/DataBoundScrollView.js
+++ b/src/components/DataBoundScrollView.js
@@ -63,11 +63,16 @@ export class DataBoundScrollView extends FlexScrollView {
         }
     }
     /**
-     * Set a template function
+     * Set a template function, optionally re-renders all the dataSource' renderables
      * @param templateFunction
      */
-    setItemTemplate(templateFunction = {}){
+    setItemTemplate(templateFunction = {},reRender = false){
         this.options.itemTemplate = templateFunction;
+
+        if(reRender){
+            this.clearDataSource();
+            this.reloadFilter(this.options.dataFilter);
+        }
     }
 
     /**
@@ -77,11 +82,10 @@ export class DataBoundScrollView extends FlexScrollView {
      * @param {Boolean} reRender Boolean to rerender all childs that pass the filter function. Usefull when setting a new itemTemplate alongside reloading the filter
      * @returns {void}
      */
-    reloadFilter(newFilter, reRender = false) {
+    reloadFilter(newFilter) {
         this.options.dataFilter = newFilter;
 
         for (let entry of this.options.dataStore) {
-            if(reRender) this._removeItem(entry);
             let surface = _.find(this._dataSource, (surface) => surface.dataId === entry.id);
             let alreadyExists = surface !== undefined;
             let result = newFilter(entry);
@@ -91,6 +95,15 @@ export class DataBoundScrollView extends FlexScrollView {
             } else {
                 this._handleNewFilterResult(result, alreadyExists, entry);
             }
+        }
+    }
+
+    /**
+     * Clears the dataSource by removing all entries
+     */
+    clearDataSource(){
+        for(let entry of this.options.dataStore){
+            this._removeItem(entry);
         }
     }
 


### PR DESCRIPTION
Extended the DBS with an setItemTemplate function, extended reloadFilter with reRender argument to force rerendering all childs when reloading the filter.

Useful if you want to set a new itemTemplate when reloading the dataFilter, thus the need to rerender all childs that pass the (new) datafilter. 
